### PR TITLE
Change Table to row arrays instead of column arrays

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ class App extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			route: 'dm'
+			route: 'phq9'
 		}
 	}
 

--- a/src/Components/Table/Table.js
+++ b/src/Components/Table/Table.js
@@ -7,28 +7,16 @@ import React from 'react';
  * columns[0][0] columns[1][0] and columns[2][0] will be in the same row.
  * Will only display a number of rows up to the shortest non-null column length.
  * @headers Headers of the table.
- * @columns Array of arrays of data in columns for the table.
- * @footers Footers of the table, in a row.
+ * @rows Array of data in rows, ideally same number of columns as headers.
+ * @footers Footers of the table, ideally same number of columns as headers.
  * @txClass Every txClass is the className for the tx element.
  */
-const Table = ({headers, columns, footers, tdClass, thClass, tClass, trClass, tfClass}) => {
-
+const Table = ({headers, rows, footers, tdClass, thClass, tClass, trClass, tfClass}) => {
     //calculates shortest column to make sure we don't
     // go over it when we map in the return.
-    if (columns) {
-        var shortestColumn;
-        columns.forEach((column,index) => {
-            if (column != null) {
-                if (!shortestColumn) { shortestColumn = index}
-                shortestColumn = column.length < columns[shortestColumn].length 
-                    ? index 
-                    : shortestColumn;
-            }
-        })
-    }
-    return(
+    return (
         <table className={tClass} cellSpacing="0">
-            {headers ?
+            {Array.isArray(headers) ?
                 <thead>
                     <tr className={trClass}>
                         {headers.map((header, index)=> {
@@ -40,26 +28,41 @@ const Table = ({headers, columns, footers, tdClass, thClass, tClass, trClass, tf
                         })}
                     </tr>
                 </thead>
-            : null
+            :   <thead>
+                    <tr className={trClass}>
+                        <th className={thClass}>
+                            {headers}
+                        </th>
+                    </tr>
+                </thead>
             }
             <tbody>
-                {columns && columns[shortestColumn] ?
-                    columns[shortestColumn].map((indexColumn, index) => {
-                    return (
-                        <tr className={trClass} key={index}>
-                            {columns.map((column,i) => {
-                                if (column) {
-                                return (
-                                    <td className={tdClass}
-                                        key={index+i}
-                                    >{column[index]}</td>
+                {Array.isArray(rows) 
+                ? rows.map((row, rowi) => {
+                    return(
+                        <tr className={trClass} key={rowi}>
+                            {Array.isArray(row)
+                            ? row.map((ele, i) => {
+                                return(
+                                    <td className={tdClass} key={rowi+i}>
+                                        {ele}
+                                    </td>
                                 )
-                                } else { return null }
-                            })}
+                            })
+                            :   <tr className={trClass}>
+                                    <td className={tdClass}>
+                                        {row}
+                                    </td>
+                                </tr>
+                            }
                         </tr>
                     )
                 })
-                : null
+                :   <tr className={trClass}>
+                        <td className={tdClass}>
+                            {rows}
+                        </td>
+                    </tr>
                 }
             </tbody>
             {footers ?

--- a/src/Containers/DailyMaintenance/DailyMaintenance.js
+++ b/src/Containers/DailyMaintenance/DailyMaintenance.js
@@ -1,10 +1,27 @@
 import React from 'react'
 
+const testTasks = [
+    {
+        taskname: "Wake up at 8 am",
+        completed: false
+    },
+    {
+        taskname: "Eat breakfast",
+        completed: true
+    },
+    {
+        taskname: "Go for a 30 minute walk",
+        completed: false
+    }
+]
+
 
 // Displays a list of tasks for a specific day
 // and renders them in a table where each task can be marked as completed or not.
 class DailyMaintenance extends React.Component {
+    
     render() {
+
         return null
     }
 }

--- a/src/Containers/PHQ9/PHQ9.js
+++ b/src/Containers/PHQ9/PHQ9.js
@@ -60,9 +60,10 @@ class PHQ9 extends React.Component {
     }
 
     render() {
-        const selectionBoxes = phq9Questions.map((question, index) => {
+        const rows = phq9Questions.map((question, index) => {
+            var selection;
             if (index < 9) {
-                return <SelectionBox
+                selection = <SelectionBox
                     id={index}
                     key={index}
                     value={this.state.answers[index]}
@@ -70,7 +71,7 @@ class PHQ9 extends React.Component {
                     onChange={this.onSelectAnswer}
                 />
             } else {
-                return <SelectionBox
+                selection = <SelectionBox
                     id={index}
                     key={index}
                     value={this.state.answers[index]}
@@ -78,8 +79,9 @@ class PHQ9 extends React.Component {
                     onChange={this.onSelectAnswer}
                 />
             }
+            return [question, selection];
         })
-       
+
         const footers = [
             '',
             <button 
@@ -98,7 +100,7 @@ class PHQ9 extends React.Component {
                 </p>
                 <Table
                     headers={phq9Headers}
-                    columns={[phq9Questions, selectionBoxes]}
+                    rows={rows}
                     footers={footers}
                     thClass="fw6 tl pa3 bg-white bb br"
                     tdClass="pa3 tl bb br"


### PR DESCRIPTION
Change of table component to use rows as arrays instead of columns as arrays logically makes more sense as that is how tables are displayed/generated in HTML. Causes less issues with having to check for data & column length. Can just map the rows directly to <tr> and <td>